### PR TITLE
Fix error in phantomjs download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,4 +55,3 @@ ENV LANG=ja_JP.UTF-8
 
 RUN \cp -p /usr/share/zoneinfo/Japan /etc/localtime \
 &&  echo 'ZONE="Asia/Tokyo"' > /etc/sysconfig/clock
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN pip install s3cmd
 
 # phantomjs install
 ENV PHANTOMJS_VERSION 2.1.1
-RUN wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2 \
+RUN wget -U "wget" --wait=5 https://github.com/paladox/phantomjs/releases/download/2.1.7/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2 \
 &&  tar xf phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2 \
 &&  mv     phantomjs-${PHANTOMJS_VERSION}-linux-x86_64/bin/phantomjs /usr/bin/phantomjs \
 &&  rm -rf phantomjs-${PHANTOMJS_VERSION}-linux-x86_64 \


### PR DESCRIPTION
Fixed. often fail download phantomjs

because Bitbucket has rate limit at file download
via. ttps://github.com/ariya/phantomjs/issues/13953#issuecomment-175749630

same to https://github.com/drecom/docker-ubuntu-base/pull/7
