### PR TITLE
Fix warning: setlocale: LC_ALL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ RUN wget -U "wget" --wait=5 https://github.com/paladox/phantomjs/releases/downlo
 
 # defaultのlocaleをja_JP.UTF-8にする
 ENV LANG=ja_JP.UTF-8
+RUN localedef -f UTF-8 -i ja_JP ja_JP.UTF-8
 
 RUN \cp -p /usr/share/zoneinfo/Japan /etc/localtime \
 &&  echo 'ZONE="Asia/Tokyo"' > /etc/sysconfig/clock


### PR DESCRIPTION
ref. http://qiita.com/amanoiverse/items/761994974686480a50b5

warning出ていたプロジェクトで `localedef -f UTF-8 -i ja_JP ja_JP.UTF-8` を実行したらwarning出なくなったのでおそらく大丈夫

Close #5
