### PR TITLE
Node.jsのver.を4.x → 6.x LTSに上げる

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,8 @@ RUN yum install -y \
 &&  yum clean all
 
 # node.js LTS install
-RUN rpm -Uvh https://rpm.nodesource.com/pub_4.x/el/6/x86_64/nodejs-4.5.0-1nodesource.el6.x86_64.rpm \
+RUN curl --silent --location https://rpm.nodesource.com/setup_6.x | bash - \
+    && yum -y install nodejs \
     && npm -g up
 
 # pip install


### PR DESCRIPTION
2016-10-18にNode.jsのLTS版が4.xから6.xに切り替わりました。_cf._ [Node v6.9.0 (LTS) | Node.js](https://nodejs.org/en/blog/release/v6.9.0/)　それに対応したものです。